### PR TITLE
Refactor: Update navigation bar links

### DIFF
--- a/edit.html
+++ b/edit.html
@@ -42,7 +42,7 @@
     <div class="relative flex size-full min-h-screen flex-col bg-white group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#f1f2f4] px-10 py-3">
-          <div class="flex items-center gap-4 text-[#121416]">
+          <a href="index.html" class="flex items-center gap-4 text-[#121416]">
             <div class="size-4">
               <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <g clip-path="url(#clip0_6_330)">
@@ -59,12 +59,10 @@
               </svg>
             </div>
             <h2 class="text-[#121416] text-lg font-bold leading-tight tracking-[-0.015em]">Photo Studio</h2>
-          </div>
+          </a>
           <div class="flex flex-1 justify-end items-center gap-8"> <!-- Added items-center -->
             <div class="flex items-center gap-9">
               <a class="text-[#121416] text-sm font-medium leading-normal" href="/" title="Home">Home</a>
-              <a class="text-[#121416] text-sm font-medium leading-normal" href="#">Pricing</a>
-              <a class="text-[#121416] text-sm font-medium leading-normal" href="#">Contact</a>
             </div>
             <button
               class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-xl h-10 px-4 bg-[#dce8f3] text-[#121416] text-sm font-bold leading-normal tracking-[0.015em] hover:bg-[#c9d8e7]"

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <div class="relative flex size-full min-h-screen flex-col bg-white group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#f0f2f5] px-10 py-3">
-          <div class="flex items-center gap-4 text-[#111418]">
+          <a href="index.html" class="flex items-center gap-4 text-[#111418]">
             <div class="size-4">
               <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <g clip-path="url(#clip0_6_330)">
@@ -34,13 +34,10 @@
               </svg>
             </div>
             <h2 class="text-[#111418] text-lg font-bold leading-tight tracking-[-0.015em]">Photo Studio</h2>
-          </div>
+          </a>
           <div class="flex flex-1 justify-end gap-8">
             <div class="flex items-center gap-9">
-              <a class="text-[#111418] text-sm font-medium leading-normal" href="#">Home</a>
-              <a class="text-[#111418] text-sm font-medium leading-normal" href="#">Features</a>
-              <a class="text-[#111418] text-sm font-medium leading-normal" href="#">Pricing</a>
-              <a class="text-[#111418] text-sm font-medium leading-normal" href="#">Support</a>
+              <a class="text-[#111418] text-sm font-medium leading-normal" href="index.html">Home</a>
             </div>
             <button
               class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 bg-[#0c7ff2] text-white text-sm font-bold leading-normal tracking-[0.015em]"


### PR DESCRIPTION
This commit modifies the navigation bars in `index.html` and `edit.html` based on the following requirements:

- Removed "Pricing", "Contact", "Support", and "Features" links from the top navigation.
- Ensured that clicking on the "Home" link in both files navigates to `index.html`.
- Ensured that clicking on the "Photo Studio" logo/text in the header of both files navigates to `index.html`.

Specific changes:

- In `index.html`:
    - Removed "Features", "Pricing", and "Support" links.
    - Updated "Home" link `href` to "index.html".
    - Wrapped logo and "Photo Studio" text with an `<a>` tag linking to "index.html".
- In `edit.html`:
    - Removed "Pricing" and "Contact" links.
    - "Home" link already correctly pointed to "/".
    - Wrapped logo and "Photo Studio" text with an `<a>` tag linking to "index.html".