### PR TITLE
feat: Add loading bar for score API call

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,12 @@
     <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
 
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <style>
+      @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+      }
+    </style>
   </head>
   <body>
     <div class="relative flex size-full min-h-screen flex-col bg-white group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
@@ -48,6 +54,11 @@
         </header>
         <div class="px-40 flex flex-1 justify-center py-5">
           <div class="layout-content-container flex flex-col max-w-[960px] flex-1">
+            <div id="loading-bar" style="display: none; text-align: center; padding: 20px;">
+              <p>Loading...</p>
+              <!-- Basic spinner -->
+              <div style="margin: auto; border: 4px solid #f3f3f3; border-top: 4px solid #3498db; border-radius: 50%; width: 30px; height: 30px; animation: spin 1s linear infinite;"></div>
+            </div>
             <div class="@container">
               <div class="@[480px]:p-4">
                 <div


### PR DESCRIPTION
Implemented a loading bar that displays while waiting for the score API to respond.

Changes include:
- Added a `div` element with an ID `loading-bar` to `index.html`. This div contains a "Loading..." message and a CSS spinner. It is hidden by default.
- Modified `script.js` to show the loading bar before initiating the `fetch` request to the score API and hide it upon completion (success or error).
- Added CSS `@keyframes` for the spinner animation within `index.html` to make the spinner rotate.