### PR TITLE
feat: Add Privacy Policy and Terms of Service pages

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -3,31 +3,145 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Privacy Policy</title>
-    <link rel="stylesheet" href="style.css"> <!-- Assuming a common stylesheet -->
+    <title>Privacy Policy - Photo Studio</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <style>
+        body {
+            font-family: Inter, "Noto Sans", sans-serif;
+        }
+        .content-wrapper {
+            max-width: 800px; /* Or any suitable width for readability */
+            margin: 0 auto;
+            padding: 2rem;
+        }
+        h1.privacy-main-title { /* More specific selector for the main policy title */
+            font-size: 1.8em; /* Slightly adjusted from generic h1 */
+            font-weight: bold;
+            margin-bottom: 1em;
+            text-align: center;
+        }
+        h2.privacy-section-title { /* More specific selector for policy section titles */
+            font-size: 1.3em; /* Slightly adjusted */
+            font-weight: bold;
+            margin-top: 1.5em;
+            margin-bottom: 0.5em;
+            border-bottom: 1px solid #eee;
+            padding-bottom: 0.3em;
+        }
+        p, ul {
+            margin-bottom: 1em;
+            line-height: 1.6;
+        }
+        ul {
+            list-style-type: disc;
+            margin-left: 2em;
+        }
+        li {
+            margin-bottom: 0.5em;
+        }
+        a {
+            color: #0c7ff2; /* Link color similar to the app */
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .site-header {
+            padding: 1rem 2rem;
+            border-bottom: 1px solid #e5e7eb; /* light gray border */
+            margin-bottom: 2rem;
+        }
+        .site-header a {
+            text-decoration: none;
+        }
+        .disclaimer {
+            background-color: #fefcbf; /* Light yellow */
+            border: 1px solid #fce98f;
+            padding: 1em;
+            margin-bottom: 1.5em;
+            border-radius: 4px;
+            font-style: italic;
+        }
+    </style>
 </head>
-<body>
-    <header>
-        <h1>Privacy Policy</h1>
+<body class="bg-gray-50 text-gray-800">
+    <header class="site-header bg-white">
+        <div class="max-w-4xl mx-auto flex justify-between items-center">
+            <h1 class="text-xl font-bold text-gray-900">Photo Studio - Privacy Policy</h1>
+            <a href="index.html" class="text-sm font-medium text-[#0c7ff2] hover:text-[#0a6fdb]">Back to Home</a>
+        </div>
     </header>
-    <main>
-        <p>Your privacy is important to us. This Privacy Policy explains how we collect, use, disclose, and safeguard your information when you visit our website.</p>
-        <p>[Your Privacy Policy content will go here...]</p>
-        <!-- Add more detailed sections as needed -->
-        <h2>1. Information We Collect</h2>
-        <p>[Details about what information is collected...]</p>
-        <h2>2. How We Use Your Information</h2>
-        <p>[Details about how the information is used...]</p>
-        <h2>3. Sharing Your Information</h2>
-        <p>[Details about sharing information with third parties...]</p>
-        <!-- Add other relevant sections -->
-    </main>
-    <footer>
-        <p>&copy; <span id="year"></span> Your Company Name. All rights reserved.</p>
-        <p><a href="/">Home</a> | <a href="terms-of-service.html">Terms of Service</a></p>
+    <div class="content-wrapper bg-white p-6 sm:p-8 md:p-10 rounded-lg shadow-md">
+        <div class="disclaimer">
+            <p><strong>Important Disclaimer:</strong> I am an AI assistant. The following Privacy Policy is a template generated based on common practices and information provided about the "ID Photo Generator" application. It is for informational purposes only and should not be considered legal advice. You MUST consult with a qualified legal professional to ensure your Privacy Policy is complete, accurate, and complies with all applicable laws and regulations (like GDPR, CCPA, etc.) relevant to your users and your application's operations. Do not use this template as a substitute for professional legal counsel.</p>
+        </div>
+
+        <h1 class="privacy-main-title">Privacy Policy for "ID Photo Generator"</h1>
+
+        <h2 class="privacy-section-title">Introduction</h2>
+        <p>Welcome to "ID Photo Generator" (referred to as "the App", "we", "us", or "our"). This Privacy Policy explains how we handle information when you use our application. Our core principle is to respect your privacy, and as such, the App is designed to process images locally on your device without uploading your photos to our servers.</p>
+
+        <h2 class="privacy-section-title">Information We Collect</h2>
+        <p>Given the nature of the App, the information we "collect" is primarily what you provide and what is processed locally:</p>
+        <ul>
+            <li><strong>Uploaded Photos:</strong> The App requires you to upload a photo to generate an ID photo. This photo is processed directly within your web browser on your device. We do not upload, store, or transmit your original or processed photos to our servers.</li>
+            <li><strong>Technical Data (Non-Personal):</strong> To improve user experience and app functionality, we may collect anonymous, aggregated data such as browser type, device type, operating system, and usage patterns (e.g., features used, session duration). This data is anonymized and cannot be used to identify you personally. We may use services like Google Analytics for this purpose, which have their own privacy policies.</li>
+            <li><strong>Configuration Settings:</strong> Preferences you set within the App, such as background color choice or selected output format, may be stored locally in your browser (e.g., using localStorage) to enhance your experience on subsequent visits.</li>
+        </ul>
+
+        <h2 class="privacy-section-title">How We Use Your Information</h2>
+        <ul>
+            <li><strong>To Provide the Service:</strong> Your uploaded photo is used solely for the purpose of generating an ID photo as per your requested edits (background removal, color change, resizing). This processing occurs entirely on your local device.</li>
+            <li><strong>To Improve the Service:</strong> Anonymized technical data helps us understand how users interact with the App, identify areas for improvement, and optimize performance.</li>
+            <li><strong>To Maintain Functionality:</strong> Locally stored settings are used to remember your preferences and provide a consistent user experience.</li>
+        </ul>
+
+        <h2 class="privacy-section-title">Data Handling and Security</h2>
+        <ul>
+            <li><strong>Local Processing:</strong> All image processing, including background removal and modifications, is performed directly in your web browser. Your images do not leave your device to be processed by our servers.</li>
+            <li><strong>No Server Storage of Images:</strong> We reiterate that we do not store your uploaded or generated photos on our servers at any point. You are responsible for saving the generated ID photo to your own device.</li>
+            <li><strong>Security Measures:</strong> While we do not transmit your photos, we implement reasonable security measures in our web application to protect against unauthorized access or alteration of the app's code and any non-personal data we might collect. However, no internet-based service can be 100% secure.</li>
+        </ul>
+
+        <h2 class="privacy-section-title">Third-Party Services</h2>
+        <p>We may use third-party services for specific functionalities:</p>
+        <ul>
+            <li><strong>Analytics:</strong> As mentioned, we may use services like Google Analytics to gather anonymous usage data. Please refer to Google Analytics' privacy policy for more information on their data practices.</li>
+            <li><strong>Advertising:</strong> If the App includes advertisements (e.g., Google AdSense), these third-party ad networks may use cookies or similar technologies to collect information about your interaction with ads. This information is used to serve relevant ads. We do not share your uploaded photos with advertisers. Please consult the privacy policies of these ad networks for details on their data collection and use.</li>
+            <li><strong>Libraries and CDNs:</strong> The App may use third-party libraries or content delivery networks (CDNs) for fonts, scripts (like Tailwind CSS), or other assets to improve performance and functionality. These services may collect technical data as per their own privacy policies.</li>
+        </ul>
+
+        <h2 class="privacy-section-title">User Rights</h2>
+        <p>Since we do not store your personal images on our servers, your control primarily relates to the data on your own device and any interactions with third-party services:</p>
+        <ul>
+            <li><strong>Access and Control of Photos:</strong> You have full control over the photos on your device. You choose which photo to upload, and you choose whether to save the generated photo.</li>
+            <li><strong>Clearing Browser Data:</strong> You can clear your browser's cache and local storage to remove any locally stored preferences or data related to the App.</li>
+            <li><strong>Managing Cookies:</strong> You can manage cookies through your browser settings, including those used by third-party services like analytics or advertising.</li>
+            <li><strong>Opting-out of Analytics/Advertising:</strong> Where applicable, you may be able to opt-out of tracking by analytics or advertising services through their respective mechanisms (e.g., Google Analytics Opt-out Browser Add-on, ad network opt-out pages).</li>
+        </ul>
+
+        <h2 class="privacy-section-title">Changes to This Policy</h2>
+        <p>We may update this Privacy Policy from time to time to reflect changes in our practices or for other operational, legal, or regulatory reasons. We will notify you of any significant changes by posting the new Privacy Policy on this page and updating the "Last Updated" date (if applicable). You are advised to review this Privacy Policy periodically for any changes.</p>
+
+        <h2 class="privacy-section-title">Contact Us</h2>
+        <p>If you have any questions or concerns about this Privacy Policy or our data practices, please contact us. (Provide a method of contact, e.g., an email address or a link to a contact form if available. For this example, let's assume a placeholder: <a href="mailto:privacy@example-photostudio.com">privacy@example-photostudio.com</a>).</p>
+
+        <h2 class="privacy-section-title">Key Sections and Considerations (Summary)</h2>
+        <p>This section is intended for you, the developer, to ensure these points are robustly and accurately addressed in your final, legally-reviewed policy.</p>
+        <ul>
+            <li><strong>Uploaded Photos:</strong> Explicitly state that photos are processed locally and NOT stored on your servers. Detail the lifecycle of an uploaded image (loaded into browser memory, processed, user downloads, then it's gone from the app's direct control unless the user re-uploads).</li>
+            <li><strong>Technical Data (Analytics):</strong> Clearly list what anonymous data is collected (e.g., browser version, OS, feature usage frequency, error occurrences). If using Google Analytics or similar, name them and link to their privacy policies. Explain the purpose (improving the app, fixing bugs).</li>
+            <li><strong>Advertising Data:</strong> If using ads (e.g., AdSense), explain that ad providers may collect data to personalize ads. Link to the ad provider's privacy policy. Clarify you don't share user photos with ad networks.</li>
+            <li><strong>Data Security:</strong> Emphasize local processing as a key security feature for images. For any non-personal data you do handle, describe your security measures.</li>
+            <li><strong>Children's Privacy:</strong> State whether the app is intended for children under 13 (or the relevant age in your jurisdiction). If not, state you do not knowingly collect personal information from children. If it is, you'll need to comply with COPPA or similar regulations, which is complex.</li>
+            <li><strong>Third-Party Links:</strong> If your app or site links to other third-party sites, state that you are not responsible for their privacy practices and users should review their policies.</li>
+            <li><strong>Cookies and Local Storage:</strong> Explain what you use them for (e.g., preferences, session information if applicable, analytics, ads). Provide information on how users can manage them.</li>
+            <li><strong>Legal Basis for Processing (e.g., for GDPR):</strong> If applicable to your users, you may need to state the legal basis for processing any data (even anonymized data for analytics might be considered if it involves cookies). This is a key area for legal advice.</li>
+            <li><strong>Data Retention (for non-image data):</strong> Explain how long any non-personal data collected (e.g., analytics logs, locally stored preferences) is kept.</li>
+            <li><strong>International Data Transfers:</strong> If any data (even anonymized analytics) is transferred across borders (e.g., if you use servers or third-party services hosted in different countries), this needs to be addressed.</li>
+        </ul>
+    </div>
+    <footer class="text-center py-10 text-sm text-gray-600">
+        @2024 Photo Studio. All rights reserved. <!-- Consistent with other pages -->
     </footer>
-    <script>
-        document.getElementById('year').textContent = new Date().getFullYear();
-    </script>
 </body>
 </html>

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -3,31 +3,127 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Terms of Service</title>
-    <link rel="stylesheet" href="style.css"> <!-- Assuming a common stylesheet -->
+    <title>Terms of Service - Photo Studio</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <style>
+        body {
+            font-family: Inter, "Noto Sans", sans-serif;
+        }
+        .content-wrapper {
+            max-width: 800px; /* Or any suitable width for readability */
+            margin: 0 auto;
+            padding: 2rem;
+        }
+        h1.terms-main-title { /* Specific class for main title */
+            font-size: 1.8em;
+            font-weight: bold;
+            margin-bottom: 1em;
+            text-align: center;
+        }
+        h2.terms-section-title { /* Specific class for section titles */
+            font-size: 1.3em;
+            font-weight: bold;
+            margin-top: 1.5em;
+            margin-bottom: 0.5em;
+            border-bottom: 1px solid #eee;
+            padding-bottom: 0.3em;
+        }
+        p, ul {
+            margin-bottom: 1em;
+            line-height: 1.6;
+        }
+        ul {
+            list-style-type: disc;
+            margin-left: 2em;
+        }
+        li {
+            margin-bottom: 0.5em;
+        }
+        a {
+            color: #0c7ff2; /* Link color similar to the app */
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        .site-header {
+            padding: 1rem 2rem;
+            border-bottom: 1px solid #e5e7eb; /* light gray border */
+            margin-bottom: 2rem;
+        }
+        .site-header a {
+            text-decoration: none;
+        }
+        .disclaimer-box { /* Style for the disclaimer */
+            background-color: #fefcbf; /* Light yellow */
+            border: 1px solid #fce063; /* Darker yellow border */
+            padding: 1em;
+            margin-bottom: 1.5em;
+            border-radius: 4px;
+            font-style: italic;
+        }
+    </style>
 </head>
-<body>
-    <header>
-        <h1>Terms of Service</h1>
+<body class="bg-gray-50 text-gray-800">
+    <header class="site-header bg-white">
+        <div class="max-w-4xl mx-auto flex justify-between items-center">
+            <h1 class="text-xl font-bold text-gray-900">Photo Studio - Terms of Service</h1>
+            <a href="index.html" class="text-sm font-medium text-[#0c7ff2] hover:text-[#0a6fdb]">Back to Home</a>
+        </div>
     </header>
-    <main>
-        <p>Please read these Terms of Service carefully before using our website.</p>
-        <p>[Your Terms of Service content will go here...]</p>
-        <!-- Add more detailed sections as needed -->
-        <h2>1. Acceptance of Terms</h2>
-        <p>[Details...]</p>
-        <h2>2. Changes to Terms</h2>
-        <p>[Details...]</p>
-        <h2>3. Use of the Service</h2>
-        <p>[Details...]</p>
-        <!-- Add other relevant sections -->
-    </main>
-    <footer>
-        <p>&copy; <span id="year"></span> Your Company Name. All rights reserved.</p>
-        <p><a href="/">Home</a> | <a href="privacy-policy.html">Privacy Policy</a></p>
+    <div class="content-wrapper bg-white p-6 sm:p-8 md:p-10 rounded-lg shadow-md">
+        <div class="disclaimer-box">
+            <p><strong>Important Disclaimer:</strong> I am an AI assistant. The following Terms of Service is a template generated based on common practices and information provided about the "ID Photo Generator" application. It is for informational purposes only and should not be considered legal advice. You MUST consult with a qualified legal professional to ensure your Terms of Service are complete, accurate, and legally sound for your specific situation and jurisdiction. Do not use this template as a substitute for professional legal counsel.</p>
+        </div>
+
+        <h1 class="terms-main-title">Terms of Service (TOS) for "ID Photo Generator"</h1>
+
+        <h2 class="terms-section-title">1. Acceptance of Terms</h2>
+        <p>By accessing or using the "ID Photo Generator" application (the "Service"), you agree to be bound by these Terms of Service ("TOS") and our Privacy Policy. If you do not agree to all the terms and conditions, then you may not access or use the Service.</p>
+
+        <h2 class="terms-section-title">2. Description of Service</h2>
+        <p>The Service allows users to upload their photographs and process them to create ID photos. Features include background removal, background color changes, and image resizing. All image processing is performed locally on the user's device. The Service does not store user-uploaded images on its servers.</p>
+
+        <h2 class="terms-section-title">3. User Responsibilities</h2>
+        <ul>
+            <li><strong>Uploaded Content:</strong> You are solely responsible for the photos you upload and process using the Service. You affirm that you own or have the necessary licenses, rights, consents, and permissions to use and authorize us to use your photos in the manner contemplated by the Service and these TOS. You agree not to upload any content that is illegal, harmful, threatening, abusive, harassing, defamatory, vulgar, obscene, or otherwise objectionable.</li>
+            <li><strong>Compliance with Laws:</strong> You agree to use the Service in compliance with all applicable local, state, national, and international laws, rules, and regulations. This includes, but is not limited to, laws regarding the creation and use of identification photos.</li>
+            <li><strong>Prohibited Uses:</strong> You may not use the Service for any unlawful purpose or to create ID photos for fraudulent purposes. You agree not to misuse the Service, including but not limited to, attempting to gain unauthorized access to our systems or engaging in any activity that disrupts, diminishes the quality of, interferes with the performance of, or impairs the functionality of the Service.</li>
+            <li><strong>Age Requirement:</strong> You must be at least 13 years old (or the minimum age required in your country to consent to online services) to use the Service. If you are under the required age, you may only use the Service with the consent of your parent or legal guardian.</li>
+        </ul>
+
+        <h2 class="terms-section-title">4. Intellectual Property</h2>
+        <ul>
+            <li><strong>Our Rights:</strong> The Service and its original content (excluding content provided by users), features, and functionality are and will remain the exclusive property of "ID Photo Generator" and its licensors. The Service is protected by copyright, trademark, and other laws of both the [Your Country/Jurisdiction] and foreign countries. Our trademarks and trade dress may not be used in connection with any product or service without our prior written consent.</li>
+            <li><strong>Your Rights:</strong> You retain all ownership rights to the photos you upload and process using the Service. We do not claim any ownership rights over your content.</li>
+            <li><strong>License to Us (for providing the service):</strong> By uploading content, you grant us a limited, worldwide, non-exclusive, royalty-free license to use, reproduce, modify (e.g., remove background, resize), and display such content solely for the purpose of operating and providing the Service to you. This license terminates when your content is deleted from your browser or you cease using the Service with that content. Since images are processed locally, this license primarily applies to the temporary handling of data within your browser session.</li>
+        </ul>
+
+        <h2 class="terms-section-title">5. Disclaimers and Limitation of Liability</h2>
+        <ul>
+            <li><strong>As-Is Service:</strong> The Service is provided on an "AS IS" and "AS AVAILABLE" basis. Your use of the Service is at your sole risk. We expressly disclaim all warranties of any kind, whether express or implied, including, but not limited to, the implied warranties of merchantability, fitness for a particular purpose, and non-infringement.</li>
+            <li><strong>No Warranty:</strong> We make no warranty that the Service will meet your requirements, or that the Service will be uninterrupted, timely, secure, error-free, or that defects will be corrected. We make no warranty regarding the accuracy or reliability of any information obtained through the Service or that the quality of any products, services, information, or other material obtained by you through the Service will meet your expectations.</li>
+            <li><strong>Limitation of Liability:</strong> To the maximum extent permitted by applicable law, in no event shall "ID Photo Generator", its affiliates, agents, directors, employees, suppliers, or licensors be liable for any indirect, incidental, special, consequential, or punitive damages, including without limitation, loss of profits, data, use, goodwill, or other intangible losses, resulting from (i) your access to or use of or inability to access or use the Service; (ii) any conduct or content of any third party on the Service; (iii) any content obtained from the Service; and (iv) unauthorized access, use, or alteration of your transmissions or content, whether based on warranty, contract, tort (including negligence), or any other legal theory, whether or not we have been informed of the possibility of such damage, and even if a remedy set forth herein is found to have failed of its essential purpose.</li>
+            <li><strong>Accuracy of Generated Photos:</strong> While the Service aims to help users create ID photos that meet common standards, we do not guarantee that photos generated by the Service will be accepted by any particular institution or authority. It is your responsibility to ensure that the generated photos meet the specific requirements of the entity to which you are submitting them.</li>
+        </ul>
+
+        <h2 class="terms-section-title">6. Termination</h2>
+        <p>We may terminate or suspend your access to the Service immediately, without prior notice or liability, for any reason whatsoever, including without limitation if you breach the TOS.</p>
+        <p>Upon termination, your right to use the Service will immediately cease. All provisions of the TOS which by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity, and limitations of liability.</p>
+
+        <h2 class="terms-section-title">7. Governing Law</h2>
+        <p>These TOS shall be governed and construed in accordance with the laws of [Your Country/State/Jurisdiction, e.g., "the State of California, United States"], without regard to its conflict of law provisions.</p>
+        <p>Our failure to enforce any right or provision of these TOS will not be considered a waiver of those rights. If any provision of these TOS is held to be invalid or unenforceable by a court, the remaining provisions of these TOS will remain in effect. These TOS constitute the entire agreement between us regarding our Service and supersede and replace any prior agreements we might have had between us regarding the Service.</p>
+
+        <h2 class="terms-section-title">8. Changes to Terms</h2>
+        <p>We reserve the right, at our sole discretion, to modify or replace these TOS at any time. If a revision is material, we will provide at least [e.g., 30 days'] notice prior to any new terms taking effect. What constitutes a material change will be determined at our sole discretion.</p>
+        <p>By continuing to access or use our Service after any revisions become effective, you agree to be bound by the revised terms. If you do not agree to the new terms, you are no longer authorized to use the Service.</p>
+
+        <h2 class="terms-section-title">9. Contact Information</h2>
+        <p>If you have any questions about these Terms, please contact us. (Provide a method of contact, e.g., an email address or a link to a contact form if available. For this example, let's assume a placeholder: <a href="mailto:terms@example-photostudio.com">terms@example-photostudio.com</a>).</p>
+
+    </div>
+    <footer class="text-center py-10 text-sm text-gray-600">
+        @2024 Photo Studio. All rights reserved.
     </footer>
-    <script>
-        document.getElementById('year').textContent = new Date().getFullYear();
-    </script>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces two new static HTML pages:
- `privacy-policy.html`
- `terms-of-service.html`

These pages contain the respective legal content you provided. They are styled using Tailwind CSS for basic readability and include a simple header with a title and a link back to the homepage, as well as a consistent footer.

The existing links in `index.html` and `edit.html` now correctly point to these new content-filled legal pages.