### PR TITLE
feat: Simplify header navigation for mobile view

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
             </div>
             <h2 class="text-[#111418] text-lg font-bold leading-tight tracking-[-0.015em]" data-translate="headerTitle">ID Photo</h2>
           </a>
-          <div class="flex flex-1 justify-end gap-8">
+          <div class="hidden md:flex flex-1 justify-end gap-8">
             <div class="flex items-center gap-9">
               <a class="text-[#111418] text-sm lg:text-base font-medium leading-normal" href="index.html" data-translate="homeLink">Home</a>
               <div class="relative">


### PR DESCRIPTION
This commit adjusts the header navigation in `index.html` to provide a cleaner experience on mobile devices, based on your feedback.

Key changes:
- The 'Home' text link, language switcher, and 'Get Started' button in the top navigation bar are now hidden on screens smaller than the `md` breakpoint (768px).
- Only the site logo (which also serves as a link to the homepage) remains visible in the header on mobile devices.
- This change is achieved by applying the `hidden md:flex` Tailwind CSS utility class to the container holding the navigation elements.

The previously verified full-width content presentation on mobile (using `px-4` padding) remains unaffected.